### PR TITLE
Set permissions correctly

### DIFF
--- a/roles/dev_deploy/defaults/main/gpg.yml
+++ b/roles/dev_deploy/defaults/main/gpg.yml
@@ -6,7 +6,7 @@ gpg_key_scenario:
   dest: "~"
   owner: "{{ ansible_user_id }}"
   group: "{{ ansible_user_id }}"
-  mode: 0664
+  mode: "0664"
 
 alt_uid: 1000
 gnupg_dir_path: '~/.gnupg'

--- a/roles/separate_build_node/tasks/install_systemd_service.yml
+++ b/roles/separate_build_node/tasks/install_systemd_service.yml
@@ -5,7 +5,7 @@
     src: "albs_build_node.service.j2"
     group: "root"
     owner: "root"
-    mode: 0644
+    mode: "0644"
 
 - name: Enable and start build node systemd service
   systemd:

--- a/roles/separate_sign_node/defaults/main/gpg.yml
+++ b/roles/separate_sign_node/defaults/main/gpg.yml
@@ -6,4 +6,4 @@ gpg_key_scenario:
   dest: "{{ home_dir }}"
   owner: "{{ service_user }}"
   group: "{{ service_group }}"
-  mode: 0664
+  mode: "0664"

--- a/roles/separate_sign_node/tasks/install_systemd_service.yml
+++ b/roles/separate_sign_node/tasks/install_systemd_service.yml
@@ -5,7 +5,7 @@
     src: "albs_sign_node.service.j2"
     group: "root"
     owner: "root"
-    mode: 0644
+    mode: "0644"
   become: "yes"
 
 - name: Enable and start build node systemd service

--- a/roles/separate_sign_node/tasks/proxy.yml
+++ b/roles/separate_sign_node/tasks/proxy.yml
@@ -4,7 +4,7 @@
   ansible.builtin.template:
     src: pulp.conf.j2
     dest: /etc/nginx/conf.d/pulp.conf
-    mode: '0644'
+    mode: "0644"
   register: nginx_conf
   become: "yes"
 


### PR DESCRIPTION
Resolves: https://github.com/AlmaLinux/build-system/issues/177

Now permission is set as intended.
```
$ stat gpg-key-scenario
  File: gpg-key-scenario
  Size: 175             Blocks: 8          IO Block: 4096   regular file
Device: fc04h/64516d    Inode: 277409576   Links: 1
Access: (0664/-rw-rw-r--)  Uid: ( 1000/almalinux)   Gid: ( 1000/almalinux)
Context: unconfined_u:object_r:user_home_t:s0
Access: 2024-02-06 01:24:37.204877840 +0000
Modify: 2024-02-06 01:24:03.571802591 +0000
Change: 2024-02-06 01:24:03.790640415 +0000
 Birth: 2024-02-06 01:24:03.571802591 +0000
```