### PR TITLE
Use https to clone build system repos

### DIFF
--- a/roles/dev_deploy/defaults/main/albs_repos.yml
+++ b/roles/dev_deploy/defaults/main/albs_repos.yml
@@ -1,10 +1,9 @@
 albs_repos:
-  albs-frontend: git@github.com:AlmaLinux/albs-frontend.git
-  albs-node: git@github.com:AlmaLinux/albs-node.git
-  albs-web-server: git@github.com:AlmaLinux/albs-web-server.git
-  albs-sign-node: git@github.com:AlmaLinux/albs-sign-node.git
-  alma-tests-cacher: git@github.com:AlmaLinux/alma-tests-cacher.git
-  repo-beholder: git@github.com:AlmaLinux/repo-beholder.git
-  alts: git@github.com:AlmaLinux/alts.git
-  albs-sign-file: git@github.com:AlmaLinux/albs-sign-file.git
-  alma-tests-cacher: https://github.com/AlmaLinux/alma-tests-cacher
+  albs-frontend: https://github.com/AlmaLinux/albs-frontend.git
+  albs-node: https://github.com/AlmaLinux/albs-node.git
+  albs-web-server: https://github.com/AlmaLinux/albs-web-server.git
+  albs-sign-node: https://github.com/AlmaLinux/albs-sign-node.git
+  alma-tests-cacher: https://github.com/AlmaLinux/alma-tests-cacher.git
+  repo-beholder: https://github.com/AlmaLinux/repo-beholder.git
+  alts: https://github.com/AlmaLinux/alts.git
+  albs-sign-file: https://github.com/AlmaLinux/albs-sign-file.git

--- a/roles/dev_deploy/tasks/common.yml
+++ b/roles/dev_deploy/tasks/common.yml
@@ -110,6 +110,18 @@
     - not use_already_cloned_repos
     - beholder_enabled or (item.key != "repo-beholder")
 
+- name: Update ALBS sources pushurl
+  tags: update-albs-sources-pushurl
+  git_config:
+    repo: "{{sources_root}}/{{ item.key }}"
+    name: remote.origin.pushurl
+    value: "git@github.com:AlmaLinux/{{ item.key }}.git"
+    scope: local
+  with_dict: "{{ albs_repos }}"
+  when:
+    - not use_already_cloned_repos
+    - beholder_enabled or (item.key != "repo-beholder")
+
 - name: Sync ALBS sources to remote host
   synchronize:
     dest: "{{ sources_root }}"


### PR DESCRIPTION
While here, remove duplicate entry for alma-tests-cacher.

Resolves: https://github.com/AlmaLinux/build-system/issues/182