### PR TITLE
Add missing compatibility flag to compose build

### DIFF
--- a/roles/dev_deploy/tasks/services.yml
+++ b/roles/dev_deploy/tasks/services.yml
@@ -31,7 +31,7 @@
       register: services
 
     - name: Create and start each service individually
-      shell: "{{ docker_compose }} -p {{ container_name_prefix }} up -d --build --force-recreate {{ item }}"
+      shell: "{{ docker_compose }} -p {{ container_name_prefix }} --compatibility up -d --build --force-recreate {{ item }}"
       args:
         chdir: "{{ sources_root }}/albs-web-server"
       when: item not in excluded_containers


### PR DESCRIPTION
When `excluded_containers` is defined, docker-compsoe task does not pass `--compatibility` flag, so container names expected in subsequent tasks are not built.

Expected behavior:
- "Create and start services" task starts
  - albs_web_server_1
  - albs_db_1
  - albs_*_1

Actual behavior:
- "Create and start services" task starts
  - albs-web_server-1
  - albs-db-1
  - albs-*-1
