### PR TITLE
Include sign_file config when enabled

### DIFF
--- a/roles/dev_deploy/defaults/main/configs.yml
+++ b/roles/dev_deploy/defaults/main/configs.yml
@@ -6,7 +6,7 @@ generated_configs:
     mode: "0644"
   - sname: albs.conf.j2
     dname: albs.conf
-    dest: "{{ sources_root }}/nginx_configs"
+    dest: "{{ sources_root }}/albs-web-server/nginx_configs"
     mode: "0644"
   - sname: alembic.ini.j2
     dname: alembic.ini

--- a/roles/dev_deploy/templates/albs.conf.j2
+++ b/roles/dev_deploy/templates/albs.conf.j2
@@ -10,6 +10,12 @@ upstream pulp {
     server pulp:80;
 }
 
+{% if 'sign_file' not in excluded_containers %}
+upstream signfile {
+    server sign_file:8000;
+}
+{% endif %}
+
 map $http_upgrade $connection_upgrade {
     default upgrade;
     '' close;
@@ -64,4 +70,11 @@ server {
         }
         proxy_pass http://pulp;
     }
+
+{% if 'sign_file' not in excluded_containers %}
+    location /sign-file/ {
+        proxy_set_header Host $http_host;
+        proxy_pass http://signfile/;
+    }
+{% endif %}
 }


### PR DESCRIPTION
Fixes: https://github.com/AlmaLinux/build-system/issues/306

I guess `sign_file` should be added to `excluded_containers` by default. But I haven't added it here because there is still a bug in the logic for excluded_containers (#25).