### PR TITLE
Use service name for pulp_host

### DIFF
--- a/roles/dev_deploy/templates/alts_config.yaml.j2
+++ b/roles/dev_deploy/templates/alts_config.yaml.j2
@@ -12,7 +12,7 @@ broker_config:
   rabbitmq_password: "{{ rabbitmq_pass }}"
   rabbitmq_vhost: "{{ rabbitmq_vhost }}"
 results_backend_config:
-  redis_host: "{{ container_name_prefix }}_redis_1"
+  redis_host: "redis"
   redis_db_number: 1
 task_default_queue: "default"
 task_acks_late: true
@@ -20,9 +20,9 @@ task_track_started: true
 artifacts_root_directory: "test_system_artifacts"
 worker_prefetch_multiplier: 1
 jwt_secret: "{{ alts_jwt_secret }}"
-bs_host: "http://{{ container_name_prefix }}_web_server_1:8000"
+bs_host: "http://web_server:8000"
 bs_token: "{{ albs_jwt }}"
 logs_uploader_config:
-  pulp_host: "http://{{ container_name_prefix }}_pulp_1"
+  pulp_host: "http://pulp"
   pulp_user: "{{ pulp_user }}"
   pulp_password: "{{ pulp_password }}"


### PR DESCRIPTION
Since django requires the hostname to be RFC compliant, using the container name for pulp_host will result in an error. Use the service name as pulp_host instead.

Change redis_host and bs_host as well for consistency.

Resolves: https://github.com/AlmaLinux/build-system/issues/316