### PR TITLE
Fix one_vm dev deploy on Ansible 2.19

### DIFF
--- a/roles/dev_deploy/tasks/common.yml
+++ b/roles/dev_deploy/tasks/common.yml
@@ -75,7 +75,7 @@
       set_fact:
         albs_jwt: "{{ generated_albs_jwt.token }}"
       when: generated_albs_jwt is defined
-  when: not albs_jwt_token
+  when: albs_jwt_token | length == 0
 
 - name: Set albs_jwt when is set via vars.yml
   tags:
@@ -83,7 +83,7 @@
     - albs_jwt_token
   set_fact:
     albs_jwt: "{{ albs_jwt_token }}"
-  when: albs_jwt_token
+  when: albs_jwt_token | length > 0
 
 - name: Set alts_jwt when is not set via vars.yml
   tags:
@@ -100,7 +100,7 @@
       set_fact:
         alts_jwt: "{{ generated_alts_jwt.token }}"
       when: generated_alts_jwt is defined
-  when: not alts_jwt_token
+  when: alts_jwt_token | length == 0
 
 - name: Set alts_jwt when is set via vars.yml
   tags:
@@ -108,7 +108,7 @@
     - alts_jwt_token
   set_fact:
     alts_jwt: "{{ alts_jwt_token }}"
-  when: alts_jwt_token
+  when: alts_jwt_token | length > 0
 
 - name: Clone ALBS sources
   tags: clone-albs-sources

--- a/roles/dev_deploy/tasks/misc.yml
+++ b/roles/dev_deploy/tasks/misc.yml
@@ -44,6 +44,18 @@
     state: started
   when: is_clean_installation.stat.exists == False
 
+- name: Wait for web_server container to be running
+  community.docker.docker_container_info:
+    name: "{{ container_name_prefix }}_web_server_1"
+  register: web_server_info
+  until: >
+    web_server_info.container is not none
+    and (web_server_info.container.State.Running | bool)
+    and not (web_server_info.container.State.Restarting | bool)
+  retries: 30
+  delay: 10
+  when: is_clean_installation.stat.exists == False
+
 - name: Bootstrap permissions
   community.docker.docker_container_exec:
     container: "{{ container_name_prefix }}_web_server_1"
@@ -129,7 +141,7 @@
   args:
     chdir: "{{ sources_root }}/albs-web-server"
   loop: "{{ pre_bootstrap_excluded_containers | default([]) }}"
-  when: pre_bootstrap_excluded_containers | default([])
+  when: pre_bootstrap_excluded_containers | default([]) | length > 0
 
 - name: Checking if GPG key exists on web_server
   tags: add_pgp_to_web_server

--- a/roles/dev_deploy/tasks/services.yml
+++ b/roles/dev_deploy/tasks/services.yml
@@ -26,7 +26,7 @@
       loop: "{{ services.stdout_lines }}"
   when:
     - docker_compose != "not found"
-    - excluded_containers or (pre_bootstrap_excluded_containers | default([]))
+    - (excluded_containers | length > 0) or (pre_bootstrap_excluded_containers | default([]) | length > 0)
 
 - name: Create and start services
   shell: "{{ docker_compose }} -p {{ container_name_prefix }} --compatibility up -d --build --force-recreate"
@@ -35,8 +35,8 @@
   register: output
   when:
     - docker_compose != "not found"
-    - not excluded_containers
-    - not (pre_bootstrap_excluded_containers | default([]))
+    - excluded_containers | length == 0
+    - pre_bootstrap_excluded_containers | default([]) | length == 0
 
 - debug:
     var: output


### PR DESCRIPTION
- Convert string/list 'when' conditionals to explicit boolean tests (jwt tokens and excluded_containers lists) so they pass the strict conditional checks introduced in Ansible 2.19.
- Wait for the web_server container to be running and not restarting before exec'ing Bootstrap permissions, avoiding a 409 race.